### PR TITLE
Remove: altLabel from TV Show in RDF

### DIFF
--- a/skos/amagi_ebu_AssetTypeCS.rdf
+++ b/skos/amagi_ebu_AssetTypeCS.rdf
@@ -207,7 +207,6 @@
   </rdf:Description>
   <rdf:Description rdf:about="https://metadata.amagi.tv/skos/amagi_ebu_AssetTypeCS#_1.1.3">
     <skos:definition>Asset Type TV Program or a Show</skos:definition>
-    <skos:altLabel xml:lang="en">Program</skos:altLabel>
     <skos:narrower rdf:resource="https://metadata.amagi.tv/skos/amagi_ebu_AssetTypeCS#_1.1.3.1"/>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#AssetType"/>
     <skos:historyNote>2023-08-27</skos:historyNote>


### PR DESCRIPTION
1. Removed altLable for TV Show (i.e Program)
2. This is because of a new prefLabel added for program