### PR TITLE
Update PT-CCE rating values

### DIFF
--- a/skos/ebu_ParentalGuidanceCodeCS_amgext.rdf
+++ b/skos/ebu_ParentalGuidanceCodeCS_amgext.rdf
@@ -669,6 +669,10 @@
     <skos:prefLabel xml:lang="en">G</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
+  <rdf:Description rdf:nodeID="A0">
+    <rdf:rest rdf:nodeID="A1"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_27"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_12.4">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -731,10 +735,6 @@
     <skos:prefLabel xml:lang="en">S</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="A0">
-    <rdf:rest rdf:nodeID="A1"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_25"/>
-  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_25.1">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -745,6 +745,10 @@
     <skos:prefLabel xml:lang="en">For all audiences</skos:prefLabel>
     <skos:prefLabel xml:lang="fr">Tout public</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A2">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_31"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_58.1.4">
     <skos:example></skos:example>
@@ -1613,6 +1617,10 @@
     <skos:prefLabel xml:lang="en">T</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
+  <rdf:Description rdf:nodeID="A3">
+    <rdf:rest rdf:nodeID="A0"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_50"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_65.1">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -1695,10 +1703,6 @@
     <skos:prefLabel xml:lang="en">M/16</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="A2">
-    <rdf:rest rdf:nodeID="A3"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_50"/>
-  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.3">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -1723,9 +1727,9 @@
          com exibição dos órgãos genitais; Serão classificados no 2º escalão (soft-core) os
          espectáculos que apresentem uma descrição ostensiva e insistente de actos sexuais
          simulados.</skos:definition>
-    <skos:definition xml:lang="en">For persons of age 18 and above, sexual
-         content</skos:definition>
-    <skos:prefLabel xml:lang="en">Pornográficos</skos:prefLabel>
+    <skos:definition xml:lang="en">Restricted to adults (18+) due to explicit/graphic content</skos:definition>
+    <skos:altLabel xml:lang="pt">Pornográficos</skos:altLabel>
+    <skos:prefLabel xml:lang="en">M/18-P</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.5">
@@ -1740,6 +1744,18 @@
     <skos:prefLabel xml:lang="en">M/18</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.8">
+    <skos:example></skos:example>
+    <skos:historyNote></skos:historyNote>
+    <skos:changeNote></skos:changeNote>
+    <skos:inScheme rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS"/>
+    <skos:broader rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42"/>
+    <skos:definition xml:lang="pt">Todos</skos:definition>
+    <skos:definition xml:lang="en">Suitable for all audiences</skos:definition>
+    <skos:altLabel xml:lang="pt">Todos</skos:altLabel>
+    <skos:prefLabel xml:lang="en">A</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.7">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -1751,6 +1767,16 @@
     <skos:definition xml:lang="en">Of quality from an artistic, thematic, pedagogic or technical
          realisation perspective</skos:definition>
     <skos:prefLabel xml:lang="en">De Qualidade</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.9">
+    <skos:example></skos:example>
+    <skos:historyNote></skos:historyNote>
+    <skos:changeNote></skos:changeNote>
+    <skos:inScheme rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS"/>
+    <skos:broader rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42"/>
+    <skos:definition xml:lang="en">For persons of age 3 and above</skos:definition>
+    <skos:prefLabel xml:lang="en">M/3</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_75.1.5">
@@ -2141,6 +2167,10 @@
     <skos:definition xml:lang="en">Accessible to persons aged 12 and over</skos:definition>
     <skos:prefLabel xml:lang="en">12</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A1">
+    <rdf:rest rdf:nodeID="A4"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_25"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_60.1.1">
     <skos:example></skos:example>
@@ -2696,8 +2726,12 @@
     <skos:prefLabel xml:lang="en">16</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
+  <rdf:Description rdf:nodeID="A5">
+    <rdf:rest rdf:nodeID="A3"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_48"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#defaultSchemesList">
-    <skos:memberList rdf:nodeID="A4"/>
+    <skos:memberList rdf:nodeID="A5"/>
     <skos:definition xml:lang="en">The ordered list of Parental Guidance top concepts to be considered when no scheme is provided for a rating</skos:definition>
     <rdfs:label xml:lang="en">Default PG Schemes List</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#OrderedCollection"/>
@@ -4379,6 +4413,16 @@
     <skos:prefLabel xml:lang="en">JP-EIRIN</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.10">
+    <skos:example></skos:example>
+    <skos:historyNote></skos:historyNote>
+    <skos:changeNote></skos:changeNote>
+    <skos:inScheme rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS"/>
+    <skos:broader rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42"/>
+    <skos:definition xml:lang="en">For persons of age 14 and above</skos:definition>
+    <skos:prefLabel xml:lang="en">M/14</skos:prefLabel>
+    <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_50.1">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -4551,6 +4595,9 @@
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42">
     <skos:note>Valid</skos:note>
+    <skos:example></skos:example>
+    <skos:historyNote>2009-07-28</skos:historyNote>
+    <skos:changeNote>Update</skos:changeNote>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
     <skos:prefLabel xml:lang="en">PT-CCE</skos:prefLabel>
     <skos:altLabel xml:lang="pt">Comissão de Classificação de Espectáculos</skos:altLabel>
@@ -4564,9 +4611,9 @@
     <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.5"/>
     <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.6"/>
     <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.7"/>
-    <skos:changeNote>Update</skos:changeNote>
-    <skos:historyNote>2009-07-28</skos:historyNote>
-    <skos:example></skos:example>
+    <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.8"/>
+    <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.9"/>
+    <skos:narrower rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_42.10"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_68.1.1">
     <skos:example></skos:example>
@@ -4799,10 +4846,6 @@
     <skos:broader rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_36.2"/>
     <skos:prefLabel xml:lang="en">Coarse language</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="A1">
-    <rdf:rest rdf:nodeID="A5"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_19"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_46">
     <skos:note>Valid</skos:note>
@@ -5957,10 +6000,6 @@
     <skos:prefLabel xml:lang="en">KR-KBS</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="A4">
-    <rdf:rest rdf:nodeID="A2"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_48"/>
-  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_47.1.3">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -6884,10 +6923,6 @@
     <skos:prefLabel xml:lang="po">D</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
   </rdf:Description>
-  <rdf:Description rdf:nodeID="A3">
-    <rdf:rest rdf:nodeID="A0"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_27"/>
-  </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_23.1.1">
     <skos:example></skos:example>
     <skos:historyNote></skos:historyNote>
@@ -7066,6 +7101,10 @@
     <skos:altLabel xml:lang="en">Mature Audience</skos:altLabel>
     <skos:prefLabel xml:lang="en">MA</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A4">
+    <rdf:rest rdf:nodeID="A2"/>
+    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_19"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_70.2">
     <skos:example></skos:example>
@@ -7250,10 +7289,6 @@
     <skos:definition xml:lang="en">Parental Guidance Suggested</skos:definition>
     <skos:prefLabel xml:lang="en">PG</skos:prefLabel>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#TargetAudience"/>
-  </rdf:Description>
-  <rdf:Description rdf:nodeID="A5">
-    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
-    <rdf:first rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_31"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS#_72.1.3">
     <skos:inScheme rdf:resource="http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS"/>

--- a/skos/ebu_ParentalGuidanceCodeCS_amgext.ttl
+++ b/skos/ebu_ParentalGuidanceCodeCS_amgext.ttl
@@ -3986,6 +3986,9 @@ parentalguidance:_42  rdf:type  ebucore:TargetAudience ;
         skos:narrower     parentalguidance:_42.5 ;
         skos:narrower     parentalguidance:_42.6 ;
         skos:narrower     parentalguidance:_42.7 ;
+        skos:narrower     parentalguidance:_42.8 ;
+        skos:narrower     parentalguidance:_42.9 ;
+        skos:narrower     parentalguidance:_42.10 ;
         skos:changeNote   "Update" ;
         skos:historyNote  "2009-07-28" ;
         skos:example      "" ;
@@ -4048,8 +4051,9 @@ parentalguidance:_42.5
 
 parentalguidance:_42.6
         rdf:type          ebucore:TargetAudience ;
-        skos:prefLabel    "Pornográficos"@en ;
-        skos:definition   "For persons of age 18 and above, sexual\n         content"@en ;
+        skos:prefLabel    "M/18-P"@en ;
+        skos:altLabel     "Pornográficos"@pt ;
+        skos:definition   "Restricted to adults (18+) due to explicit/graphic content"@en ;
         skos:definition   "Serão classificados no 1º escalão (hard-core) os espectáculos\n         que apresentem uma descrição ostensiva e insistente de actos sexuais realmente praticados\n         com exibição dos órgãos genitais; Serão classificados no 2º escalão (soft-core) os\n         espectáculos que apresentem uma descrição ostensiva e insistente de actos sexuais\n         simulados."@pt ;
         skos:broader      parentalguidance:_42 ;
         skos:inScheme     <http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS> ;
@@ -4062,6 +4066,38 @@ parentalguidance:_42.7
         skos:prefLabel    "De Qualidade"@en ;
         skos:definition   "Of quality from an artistic, thematic, pedagogic or technical\n         realisation perspective"@en ;
         skos:definition   "Os espectáculos que, pelos seus aspectos artístico, temático,\n         pedagógico e técnico mereçam esse atributo."@pt ;
+        skos:broader      parentalguidance:_42 ;
+        skos:inScheme     <http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS> ;
+        skos:changeNote   "" ;
+        skos:historyNote  "" ;
+        skos:example      "" .
+
+parentalguidance:_42.8
+        rdf:type          ebucore:TargetAudience ;
+        skos:prefLabel    "A"@en ;
+        skos:altLabel     "Todos"@pt ;
+        skos:definition   "Suitable for all audiences"@en ;
+        skos:definition   "Todos"@pt ;
+        skos:broader      parentalguidance:_42 ;
+        skos:inScheme     <http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS> ;
+        skos:changeNote   "" ;
+        skos:historyNote  "" ;
+        skos:example      "" .
+
+parentalguidance:_42.9
+        rdf:type          ebucore:TargetAudience ;
+        skos:prefLabel    "M/3"@en ;
+        skos:definition   "For persons of age 3 and above"@en ;
+        skos:broader      parentalguidance:_42 ;
+        skos:inScheme     <http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS> ;
+        skos:changeNote   "" ;
+        skos:historyNote  "" ;
+        skos:example      "" .
+
+parentalguidance:_42.10
+        rdf:type          ebucore:TargetAudience ;
+        skos:prefLabel    "M/14"@en ;
+        skos:definition   "For persons of age 14 and above"@en ;
         skos:broader      parentalguidance:_42 ;
         skos:inScheme     <http://www.ebu.ch/metadata/ontologies/skos/ebu_ParentalGuidanceCodeCS> ;
         skos:changeNote   "" ;


### PR DESCRIPTION
- Add support for the following additional rating values:
  - A (i.e, Todos)
  - M/3
  - M/14
- Rename the preferred label Pornográficos to M/18-P.
  - Pornográficos corresponds to the M/18-P rating. I queried GMS and verified that there are currently no assets using the Pornográficos rating. Therefore, updating the preferred label to M/18-P will not impact any existing assets while aligning the terminology with the standard rating nomenclature.