### PR TITLE
add: ReconcileID identifier type

### DIFF
--- a/skos/amagi_ebu_IdentifierTypeCS.rdf
+++ b/skos/amagi_ebu_IdentifierTypeCS.rdf
@@ -1765,4 +1765,14 @@
     <skos:changeNote>First version</skos:changeNote>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IdentifierType"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS#_reconcileid">
+    <skos:prefLabel xml:lang="en">ReconcileID</skos:prefLabel>
+    <skos:note>Valid</skos:note>
+    <skos:inScheme rdf:resource="https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS"/>
+    <skos:historyNote>2026-07-17</skos:historyNote>
+    <skos:example></skos:example>
+    <skos:definition xml:lang="en">ReconcileID identifier</skos:definition>
+    <skos:changeNote>First version</skos:changeNote>
+    <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IdentifierType"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/skos/amagi_ebu_IdentifierTypeCS.ttl
+++ b/skos/amagi_ebu_IdentifierTypeCS.ttl
@@ -1758,6 +1758,16 @@
     skos:note "Valid" ;
     skos:prefLabel "De A Planeta"@en .
 
+<https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS#_reconcileid>
+    a ebucore:IdentifierType ;
+    skos:changeNote """First version""" ;
+    skos:definition """ReconcileID identifier"""@en ;
+    skos:example "" ;
+    skos:historyNote "2026-07-17" ;
+    skos:inScheme <https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS> ;
+    skos:note "Valid" ;
+    skos:prefLabel "ReconcileID"@en .
+
 <https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS#_vendor_context_id>
     a ebucore:IdentifierType ;
     skos:changeNote """First version""" ;

--- a/skos/amagi_ebu_IdentifierTypeCS_amgext.rdf
+++ b/skos/amagi_ebu_IdentifierTypeCS_amgext.rdf
@@ -1765,4 +1765,14 @@
     <skos:changeNote>First version</skos:changeNote>
     <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IdentifierType"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS#_reconcileid">
+    <skos:prefLabel xml:lang="en">ReconcileID</skos:prefLabel>
+    <skos:note>Valid</skos:note>
+    <skos:inScheme rdf:resource="https://metadata.amagi.tv/skos/amagi_ebu_IdentifierTypeCS"/>
+    <skos:historyNote>2026-07-17</skos:historyNote>
+    <skos:example></skos:example>
+    <skos:definition xml:lang="en">ReconcileID identifier</skos:definition>
+    <skos:changeNote>First version</skos:changeNote>
+    <rdf:type rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#IdentifierType"/>
+  </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
## Summary
- Adds new `ReconcileID` identifier type to the SKOS concept scheme
- Fragment key: `#_reconcileid`, prefLabel: `ReconcileID`
- Regenerated both RDF serializations from the updated TTL

