### PR TITLE
Add preprocessType property to MediaResource

### DIFF
--- a/ebucore/amagi_ebucoreExtension.rdf
+++ b/ebucore/amagi_ebucoreExtension.rdf
@@ -914,4 +914,11 @@
     <rdfs:domain rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#Asset"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://metadata.amagi.tv/ebu/amagi_ebucoreExtension#preprocessType">
+    <rdfs:label xml:lang="en">Preprocess Type</rdfs:label>
+    <rdfs:comment xml:lang="en">The type of preprocessing applied to the media resource before ingestion (e.g., hard_segment, m3u8_to_ts).</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:domain rdf:resource="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#MediaResource"/>
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/ebucore/amagi_ebucoreExtension.ttl
+++ b/ebucore/amagi_ebucoreExtension.ttl
@@ -1015,6 +1015,13 @@
     rdfs:comment  "The pcr pid of the media resource."@en ;
     rdfs:label    "Pcr Pid"@en .
 
+<https://metadata.amagi.tv/ebu/amagi_ebucoreExtension#preprocessType>
+    rdf:type      rdf:Property ;
+    rdfs:domain   ebucore:MediaResource ;
+    rdfs:range    <http://www.w3.org/2001/XMLSchema#string> ;
+    rdfs:comment  "The type of preprocessing applied to the media resource before ingestion (e.g., hard_segment, m3u8_to_ts)."@en ;
+    rdfs:label    "Preprocess Type"@en .
+
 <https://metadata.amagi.tv/ebu/amagi_ebucoreExtension#pid>
     rdf:type      rdf:Property ;
     rdfs:domain   ebucore:AudioTrack, ebucore:VideoTrack, ebucore:SubtitleTrack;


### PR DESCRIPTION
## Summary

- Adds `ebucoreext:preprocessType` as a new `rdf:Property` scoped to `ebucore:MediaResource`
- Type: `xsd:string` — stores values like `hard_segment`, `m3u8_to_ts`
- Added to both `amagi_ebucoreExtension.ttl` (source) and `amagi_ebucoreExtension.rdf` (RDF/XML mirror)
- No existing declarations modified

## Context

Part of the preprocessing feature: assets requiring preprocessing before ingestion (e.g., merging hard segments, generating TS from M3U8) will have this field set on their media resource. The Ingest Worker sends `preprocess_type` in the TTL payload; CMW/GMS stores it under `media_resources`.

- https://amagiengg.atlassian.net/wiki/spaces/MI/pages/5414912242/Ingest+Preprocessor+Preprocessing+Workflow+Integration